### PR TITLE
add dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
I'm unable to use your library with the latest nestjs, I believe that's because of the outdated libraries
```json
{
    "@nestjs/common": "^8.2.0",
    "@nestjs/graphql": "^9.1.1",
    "class-transformer": "^0.4.0",
}
```